### PR TITLE
PNPG-163 Responsive mobile select business and same padding for the title+subtitle and paper component

### DIFF
--- a/src/api/__mocks__/DashboardApi.ts
+++ b/src/api/__mocks__/DashboardApi.ts
@@ -51,19 +51,6 @@ export const mockedInstitutionsResource: Array<PnPGInstitutionResource> = [
     origin: 'ADE',
     institutionType: 'Azienda privata',
   },
-  {
-    userRole: 'ADMIN',
-    name: 'mockedBusiness4',
-    status: 'ACTIVE',
-    id: '5b971318-3df7-11c1-67c8-1111e6707dgt',
-    fiscalCode: '05923570510',
-    mailAddress: 'mockemail4@mocktest.com',
-    category: '',
-    externalId: '05923570510',
-    originId: 'originId1',
-    origin: 'ADE',
-    institutionType: 'Azienda privata',
-  },
 ];
 
 export const mockedInstitutionsResource2Party =

--- a/src/api/__mocks__/DashboardApi.ts
+++ b/src/api/__mocks__/DashboardApi.ts
@@ -51,6 +51,19 @@ export const mockedInstitutionsResource: Array<PnPGInstitutionResource> = [
     origin: 'ADE',
     institutionType: 'Azienda privata',
   },
+  {
+    userRole: 'ADMIN',
+    name: 'mockedBusiness4',
+    status: 'ACTIVE',
+    id: '5b971318-3df7-11c1-67c8-1111e6707dgt',
+    fiscalCode: '05923570510',
+    mailAddress: 'mockemail4@mocktest.com',
+    category: '',
+    externalId: '05923570510',
+    originId: 'originId1',
+    origin: 'ADE',
+    institutionType: 'Azienda privata',
+  },
 ];
 
 export const mockedInstitutionsResource2Party =

--- a/src/pages/partySelectionContainer/partySelection/PartySelection.tsx
+++ b/src/pages/partySelectionContainer/partySelection/PartySelection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Grid, Button, Paper, useTheme, Typography, Stack, Box, Link } from '@mui/material';
+import { Grid, Button, Paper, useTheme, Typography, Stack, Link } from '@mui/material';
 import { useHistory } from 'react-router';
 import { resolvePathVariables } from '@pagopa/selfcare-common-frontend/utils/routes-utils';
 import { trackEvent } from '@pagopa/selfcare-common-frontend/services/analyticsService';
@@ -51,12 +51,31 @@ export default function PartySelection({ parties }: Props) {
       spacing={2}
       my={'auto'}
     >
-      <Grid item container mb={3} xs={12}>
+      <Grid item container mb={3} xs={12} textAlign="center">
         <Grid item xs={12} mb={1} display="flex" justifyContent="center">
-          <Typography variant="h3">{bodyTitle}</Typography>
+          <Typography
+            variant="h3"
+            sx={{
+              [theme.breakpoints.down('md')]: {
+                maxWidth: '480px',
+                width: '100%',
+              },
+            }}
+          >
+            {bodyTitle}
+          </Typography>
         </Grid>
-        <Grid item xs={18} display="flex" justifyContent="center">
-          <Typography variant="body1" align="center">
+        <Grid item xs={12} display="flex" justifyContent="center">
+          <Typography
+            variant="body1"
+            align="center"
+            sx={{
+              [theme.breakpoints.down('md')]: {
+                maxWidth: '480px',
+                width: '100%',
+              },
+            }}
+          >
             {t('businessSelection.subTitle')}
           </Typography>
         </Grid>
@@ -67,14 +86,14 @@ export default function PartySelection({ parties }: Props) {
           elevation={8}
           sx={{
             maxWidth: '480px',
-            minWidth: '480px',
+            width: '100%',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
             borderRadius: theme.spacing(2),
           }}
         >
-          <Grid container item xs={3} md={4} lg={3} sx={{ minWidth: '100%', p: 2 }}>
+          <Grid container item xs={12} sx={{ p: 2 }}>
             <PartySelectionSearch
               iconColor={'#17324D'}
               label={t('businessSelection.search')}
@@ -87,8 +106,16 @@ export default function PartySelection({ parties }: Props) {
           </Grid>
         </Paper>
       </Grid>
-      <Grid item container xs={12} display="flex" justifyContent="center" mt={4}>
-        <Stack direction="row" display="flex" justifyContent="center">
+      <Grid
+        item
+        container
+        xs={12}
+        display="flex"
+        justifyContent="center"
+        mt={4}
+        sx={{ flexDirection: 'column', alignItems: 'center' }}
+      >
+        <Stack>
           <Button
             variant="contained"
             disabled={disableBtn}
@@ -100,41 +127,33 @@ export default function PartySelection({ parties }: Props) {
                 })
               );
             }}
+            sx={{ width: '100%', maxWidth: '480px' }}
           >
             {t('businessSelection.signIn')}
           </Button>
         </Stack>
-      </Grid>
-      <Grid item xs={6} mt={4}>
-        <Box
+        <Typography
           sx={{
-            fontSize: '18px',
-            lineHeight: '24px',
             textAlign: 'center',
+            marginTop: 6,
           }}
+          variant="caption"
+          color={theme.palette.text.primary}
         >
-          <Typography
-            sx={{
-              textAlign: 'center',
-            }}
-            variant="caption"
-            color={theme.palette.text.primary}
-          >
-            <Trans i18nKey="businessSelection.onboardAnotherBusiness">
-              {'Sei un Legale Rappresentante? '}
-              <Link
-                onClick={() => window.location.assign(ENV.URL_FE.ONBOARDING)}
-                sx={{
-                  textDecoration: 'underline',
-                  cursor: 'pointer',
-                  color: theme.palette.primary.main,
-                }}
-              >
-                {'Registra una nuova impresa'}
-              </Link>
-            </Trans>
-          </Typography>
-        </Box>
+          <Trans i18nKey="businessSelection.onboardAnotherBusiness">
+            {'Sei un Legale Rappresentante? '}
+            <Link
+              onClick={() => window.location.assign(ENV.URL_FE.ONBOARDING)}
+              sx={{
+                textDecoration: 'underline',
+                cursor: 'pointer',
+                color: theme.palette.primary.main,
+              }}
+            >
+              {'Registra una nuova impresa'}
+            </Link>
+          </Trans>
+        </Typography>
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

The select business page is now responsive mobile, the paper component it will adapt to the screen size as well as the title and subtitle, the latter as soon as you switch to the mobile version, will have the same width as the paper component

#### Motivation and Context

Changes requested by the PN team

#### How Has This Been Tested?
Browsing the portal from a mobile device or simulating it from a web browser by reducing the screen size, the components of the business selection page will decrease as the screen size decreases

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.