### PR TITLE
[SELC-5011] Feat: Predisposition for reading the language from query parameter

### DIFF
--- a/openApi/dashboard-pnpg-api-docs.json
+++ b/openApi/dashboard-pnpg-api-docs.json
@@ -116,113 +116,6 @@
         } ]
       }
     },
-    "/v1/institutions" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getInstitutions",
-        "description" : "Service to get all the institutions related to logged user",
-        "operationId" : "getInstitutionsUsingGET",
-        "parameters" : [ {
-          "name" : "authenticated",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "boolean"
-          }
-        }, {
-          "name" : "authorities[0].authority",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "credentials",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
-          "name" : "details",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
-          "name" : "principal",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/InstitutionBaseResource"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
     "/v1/institutions/products" : {
       "get" : {
         "tags" : [ "institutions" ],
@@ -595,6 +488,45 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "name" : "search",
+          "in" : "query",
+          "description" : "Institution's name to search",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "order",
+          "in" : "query",
+          "description" : "Order to show response NONE, ASC, DESC",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC", "NONE" ]
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "page",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "size",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
         } ],
         "responses" : {
           "200" : {
@@ -826,461 +758,6 @@
         } ]
       }
     },
-    "/v1/institutions/{institutionId}/products/{productId}/users" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getInstitutionProductUsers",
-        "description" : "Service to get all the users related to a specific pair of institution-product",
-        "operationId" : "getInstitutionProductUsersUsingGET",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "path",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "productId",
-          "in" : "path",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "role",
-          "in" : "query",
-          "description" : "User's role",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ADMIN", "LIMITED" ]
-          }
-        }, {
-          "name" : "productRoles",
-          "in" : "query",
-          "description" : "User's roles in product",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/ProductUserResource"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      },
-      "post" : {
-        "tags" : [ "institutions" ],
-        "summary" : "createInstitutionProductUser",
-        "description" : "Service to Create a user related to a specific pair of institution-product",
-        "operationId" : "createInstitutionProductUserUsingPOST",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "path",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "productId",
-          "in" : "path",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateUserDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Created",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserIdResource"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/institutions/{institutionId}/products/{productId}/users/{userId}" : {
-      "put" : {
-        "tags" : [ "institutions" ],
-        "summary" : "addUserProductRoles",
-        "description" : "Service to add a new role/product to a specific user",
-        "operationId" : "addUserProductRolesUsingPUT",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "path",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "productId",
-          "in" : "path",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "userId",
-          "in" : "path",
-          "description" : "User's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UserProductRoles"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Created"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/institutions/{institutionId}/users" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getInstitutionUsers",
-        "description" : "Service to get all the users related to a specific institution",
-        "operationId" : "getInstitutionUsersUsingGET",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "path",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "productId",
-          "in" : "query",
-          "description" : "Product's unique identifier",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "role",
-          "in" : "query",
-          "description" : "User's role",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ADMIN", "LIMITED" ]
-          }
-        }, {
-          "name" : "productRoles",
-          "in" : "query",
-          "description" : "User's roles in product",
-          "required" : false,
-          "style" : "form",
-          "explode" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/InstitutionUserResource"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "deprecated" : true,
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/institutions/{institutionId}/users/{userId}" : {
-      "get" : {
-        "tags" : [ "institutions" ],
-        "summary" : "getInstitutionUser",
-        "description" : "Service to get the users with the given user id related to a specific institution",
-        "operationId" : "getInstitutionUserUsingGET",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "path",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "userId",
-          "in" : "path",
-          "description" : "User's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/InstitutionUserDetailsResource"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
     "/v2/institutions" : {
       "get" : {
         "tags" : [ "institutions" ],
@@ -1411,6 +888,131 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/InstitutionResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/v2/institutions/{institutionId}/institutions" : {
+      "get" : {
+        "tags" : [ "institutions" ],
+        "summary" : "Retrieve list of delegation using to",
+        "description" : "Retrieve list of delegation using to",
+        "operationId" : "getDelegationsUsingToUsingGET_1",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "path",
+          "description" : "Technical partner's identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "query",
+          "description" : "Product's identifier",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "search",
+          "in" : "query",
+          "description" : "Institution's name to search",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "order",
+          "in" : "query",
+          "description" : "Order to show response NONE, ASC, DESC",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC", "NONE" ]
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "page",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "minimum" : 0,
+            "exclusiveMinimum" : false,
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "size",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "minimum" : 1,
+            "exclusiveMinimum" : false,
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DelegationWithPagination"
                 }
               }
             }
@@ -1747,362 +1349,6 @@
         } ]
       }
     },
-    "/v1/onboarding-requests/approve/{tokenId}" : {
-      "post" : {
-        "tags" : [ "onboarding" ],
-        "summary" : "approveOnboardingRequest",
-        "description" : "Service to approve a specific onboarding request",
-        "operationId" : "approveOnboardingRequestUsingPOST",
-        "parameters" : [ {
-          "name" : "tokenId",
-          "in" : "path",
-          "description" : "Onboarding request's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string",
-            "format" : "uuid"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/onboarding-requests/reject/{tokenId}" : {
-      "delete" : {
-        "tags" : [ "onboarding" ],
-        "summary" : "rejectOnboardingRequest",
-        "description" : "Service to reject a specific onboarding request",
-        "operationId" : "rejectOnboardingRequestUsingDELETE",
-        "parameters" : [ {
-          "name" : "tokenId",
-          "in" : "path",
-          "description" : "Onboarding request's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string",
-            "format" : "uuid"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/onboarding-requests/{tokenId}" : {
-      "get" : {
-        "tags" : [ "onboarding" ],
-        "summary" : "retrieveOnboardingRequest",
-        "description" : "Service to retrieve a specific onboarding request",
-        "operationId" : "retrieveOnboardingRequestUsingGET",
-        "parameters" : [ {
-          "name" : "tokenId",
-          "in" : "path",
-          "description" : "Onboarding request's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string",
-            "format" : "uuid"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/OnboardingRequestResource"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/pnPGInstitutions/{institutionId}/products" : {
-      "get" : {
-        "tags" : [ "pnPGInstitutions" ],
-        "summary" : "getPnPGInstitutionProducts",
-        "description" : "Service to get all the products related to a specific institution",
-        "operationId" : "getPnPGInstitutionProductsUsingGET",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "path",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/components/schemas/PartyProduct"
-                  }
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/products/{productId}/back-office" : {
-      "get" : {
-        "tags" : [ "products" ],
-        "summary" : "retrieveProductBackoffice",
-        "description" : "Service to trigger token exchange and redirect to product's back office URL",
-        "operationId" : "retrieveProductBackofficeUsingGET",
-        "parameters" : [ {
-          "name" : "productId",
-          "in" : "path",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "environment",
-          "in" : "query",
-          "description" : "Back Office environment",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "format" : "uri"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
     "/v1/products/{productId}/brokers/{institutionType}" : {
       "get" : {
         "tags" : [ "products" ],
@@ -2357,283 +1603,12 @@
         } ]
       }
     },
-    "/v1/relationships/{relationshipId}" : {
-      "delete" : {
-        "tags" : [ "relationships" ],
-        "summary" : "deleteRelationshipById",
-        "description" : "Delete the relationship",
-        "operationId" : "deleteRelationshipByIdUsingDELETE",
-        "parameters" : [ {
-          "name" : "relationshipId",
-          "in" : "path",
-          "description" : "Unique relationship identifier between User and Product",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/relationships/{relationshipId}/activate" : {
-      "post" : {
-        "tags" : [ "relationships" ],
-        "summary" : "activateRelationship",
-        "description" : "Activate the relationship",
-        "operationId" : "activateRelationshipUsingPOST",
-        "parameters" : [ {
-          "name" : "relationshipId",
-          "in" : "path",
-          "description" : "Unique relationship identifier between User and Product",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/relationships/{relationshipId}/suspend" : {
-      "post" : {
-        "tags" : [ "relationships" ],
-        "summary" : "suspendRelationship",
-        "description" : "Suspend the relationship",
-        "operationId" : "suspendRelationshipUsingPOST",
-        "parameters" : [ {
-          "name" : "relationshipId",
-          "in" : "path",
-          "description" : "Unique relationship identifier between User and Product",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
     "/v1/support" : {
       "post" : {
         "tags" : [ "external-v2", "support" ],
         "summary" : "sendSupportRequest",
         "description" : "Service to retrieve Support contact's form",
         "operationId" : "sendSupportRequestUsingPOST",
-        "parameters" : [ {
-          "name" : "authenticated",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "boolean"
-          }
-        }, {
-          "name" : "authorities[0].authority",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "credentials",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
-          "name" : "details",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        }, {
-          "name" : "principal",
-          "in" : "query",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "object"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SupportRequestDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "text/html" : {
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/support/request" : {
-      "post" : {
-        "tags" : [ "support" ],
-        "summary" : "getSupportRedirectUrl",
-        "description" : "Service to retrieve Support contact's form",
-        "operationId" : "getSupportRedirectUrlUsingPOST",
         "parameters" : [ {
           "name" : "authenticated",
           "in" : "query",
@@ -2707,181 +1682,6 @@
           },
           "401" : {
             "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "deprecated" : true,
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/token/exchange" : {
-      "get" : {
-        "tags" : [ "token" ],
-        "summary" : "exchange",
-        "description" : "Service create an 'Identity Token' based on a Self Care session token",
-        "operationId" : "exchangeUsingGET",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "productId",
-          "in" : "query",
-          "description" : "Product's unique identifier",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "environment",
-          "in" : "query",
-          "description" : "Back Office environment",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/IdentityTokenResource"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/token/exchange/fatturazione" : {
-      "get" : {
-        "tags" : [ "token" ],
-        "summary" : "billingToken",
-        "description" : "Service to create a 'Billing Token' based on a Self Care session token",
-        "operationId" : "billingTokenUsingGET",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "environment",
-          "in" : "query",
-          "description" : "Back Office environment",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "string",
-                  "format" : "uri"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
@@ -3002,7 +1802,7 @@
         "tags" : [ "token" ],
         "summary" : "billingToken",
         "description" : "Service to create a 'Billing Token' based on a Self Care session token",
-        "operationId" : "billingTokenUsingGET_1",
+        "operationId" : "billingTokenUsingGET",
         "parameters" : [ {
           "name" : "authenticated",
           "in" : "query",
@@ -3128,372 +1928,7 @@
         } ]
       }
     },
-    "/v1/users" : {
-      "post" : {
-        "tags" : [ "user" ],
-        "summary" : "saveUser",
-        "description" : "Save new user",
-        "operationId" : "saveUserUsingPOST",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UserDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Created",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserIdResource"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/users/search" : {
-      "post" : {
-        "tags" : [ "user" ],
-        "summary" : "search",
-        "description" : "Retrieve the user for a given fiscal code",
-        "operationId" : "searchUsingPOST",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SearchUserDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserResource"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/users/{id}" : {
-      "get" : {
-        "tags" : [ "user" ],
-        "summary" : "getUserByInternalId",
-        "description" : "Retrieve the user by internal id",
-        "operationId" : "getUserByInternalIdUsingGET",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "User's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string",
-            "format" : "uuid"
-          }
-        }, {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserResource"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      },
-      "put" : {
-        "tags" : [ "user" ],
-        "summary" : "updateUser",
-        "description" : "Update previously added user",
-        "operationId" : "updateUserUsingPUT",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "User's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string",
-            "format" : "uuid"
-          }
-        }, {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Institution's unique internal identifier",
-          "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateUserDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      },
-      "delete" : {
-        "tags" : [ "user" ],
-        "summary" : "deleteUserById",
-        "description" : "Delete user using internal id",
-        "operationId" : "deleteUserByIdUsingDELETE",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "User's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string",
-            "format" : "uuid"
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v1/user-groups" : {
+    "/v2/user-groups" : {
       "get" : {
         "tags" : [ "user-groups" ],
         "summary" : "getUserGroups",
@@ -3620,7 +2055,7 @@
         } ]
       }
     },
-    "/v1/user-groups/" : {
+    "/v2/user-groups/" : {
       "post" : {
         "tags" : [ "user-groups" ],
         "summary" : "createUserGroup",
@@ -3685,7 +2120,7 @@
         } ]
       }
     },
-    "/v1/user-groups/{id}" : {
+    "/v2/user-groups/{id}" : {
       "get" : {
         "tags" : [ "user-groups" ],
         "summary" : "getUserGroupById",
@@ -3887,7 +2322,7 @@
         } ]
       }
     },
-    "/v1/user-groups/{id}/activate" : {
+    "/v2/user-groups/{id}/activate" : {
       "post" : {
         "tags" : [ "user-groups" ],
         "summary" : "activateUserGroup",
@@ -3943,7 +2378,7 @@
         } ]
       }
     },
-    "/v1/user-groups/{id}/members/{userId}" : {
+    "/v2/user-groups/{id}/members/{userId}" : {
       "post" : {
         "tags" : [ "user-groups" ],
         "summary" : "addMemberToUserGroup",
@@ -4009,7 +2444,7 @@
         } ]
       }
     },
-    "/v1/user-groups/{id}/suspend" : {
+    "/v2/user-groups/{id}/suspend" : {
       "post" : {
         "tags" : [ "user-groups" ],
         "summary" : "suspendUserGroup",
@@ -4065,650 +2500,12 @@
         } ]
       }
     },
-    "/v1/user-groups/{userGroupId}/members/{userId}" : {
-      "delete" : {
-        "tags" : [ "user-groups" ],
-        "summary" : "deleteMemberFromUserGroup",
-        "description" : "Service to delete a member from a specific UserGroup entity",
-        "operationId" : "deleteMemberFromUserGroupUsingDELETE",
-        "parameters" : [ {
-          "name" : "userGroupId",
-          "in" : "path",
-          "description" : "Users group's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "userId",
-          "in" : "path",
-          "description" : "User's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string",
-            "format" : "uuid"
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v2/user-groups" : {
-      "get" : {
-        "tags" : [ "user-groups" ],
-        "summary" : "getUserGroups",
-        "description" : "Service that allows to get a list of UserGroup entities",
-        "operationId" : "getUserGroupsUsingGET_1",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Users group's institutionId",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "The page number to access (0 indexed, defaults to 0)",
-          "required" : false,
-          "style" : "form",
-          "allowReserved" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "size",
-          "in" : "query",
-          "description" : "Number of records per page (defaults to 20, max 2000)",
-          "required" : false,
-          "style" : "form",
-          "allowReserved" : true,
-          "schema" : {
-            "type" : "integer",
-            "format" : "int32"
-          }
-        }, {
-          "name" : "sort",
-          "in" : "query",
-          "description" : "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-          "required" : false,
-          "style" : "form",
-          "allowReserved" : true,
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string"
-            }
-          }
-        }, {
-          "name" : "productId",
-          "in" : "query",
-          "description" : "Users group's productId",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "userId",
-          "in" : "query",
-          "description" : "User's unique identifier",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "format" : "uuid"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/PageOfUserGroupPlainResource"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v2/user-groups/" : {
-      "post" : {
-        "tags" : [ "user-groups" ],
-        "summary" : "createUserGroup",
-        "description" : "Service that allows the insert of a new occurrence for the UserGroup entity",
-        "operationId" : "createUserGroupUsingPOST_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateUserGroupDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "201" : {
-            "description" : "Created",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserGroupIdResource"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict"
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v2/user-groups/{id}" : {
-      "get" : {
-        "tags" : [ "user-groups" ],
-        "summary" : "getUserGroupById",
-        "description" : "Service to get a specific UserGroup entity",
-        "operationId" : "getUserGroupByIdUsingGET_1",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "Users group's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "institutionId",
-          "in" : "query",
-          "description" : "Users group's institutionId",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserGroupResource"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "Not Found",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      },
-      "put" : {
-        "tags" : [ "user-groups" ],
-        "summary" : "updateUserGroup",
-        "description" : "Service that allows the modification of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId" : "updateUserGroupUsingPUT_1",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "Users group's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateUserGroupDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict"
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      },
-      "delete" : {
-        "tags" : [ "user-groups" ],
-        "summary" : "deleteUserGroup",
-        "description" : "Service that allows the deletion of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId" : "deleteUserGroupUsingDELETE_1",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "Users group's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v2/user-groups/{id}/activate" : {
-      "post" : {
-        "tags" : [ "user-groups" ],
-        "summary" : "activateUserGroup",
-        "description" : "Service that allows the activation of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId" : "activateUserGroupUsingPOST_1",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "Users group's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v2/user-groups/{id}/members/{userId}" : {
-      "post" : {
-        "tags" : [ "user-groups" ],
-        "summary" : "addMemberToUserGroup",
-        "description" : "Service to add a member to a specific UserGroup entity",
-        "operationId" : "addMemberToUserGroupUsingPOST_1",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "Users group's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "userId",
-          "in" : "path",
-          "description" : "User's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string",
-            "format" : "uuid"
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
-    "/v2/user-groups/{id}/suspend" : {
-      "post" : {
-        "tags" : [ "user-groups" ],
-        "summary" : "suspendUserGroup",
-        "description" : "Service that allows the suspension of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId" : "suspendUserGroupUsingPOST_1",
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "Users group's unique identifier",
-          "required" : true,
-          "style" : "simple",
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
     "/v2/user-groups/{userGroupId}/members/{userId}" : {
       "delete" : {
         "tags" : [ "user-groups" ],
         "summary" : "deleteMemberFromUserGroup",
         "description" : "Service to delete a member from a specific UserGroup entity",
-        "operationId" : "deleteMemberFromUserGroupUsingDELETE_1",
+        "operationId" : "deleteMemberFromUserGroupUsingDELETE",
         "parameters" : [ {
           "name" : "userGroupId",
           "in" : "path",
@@ -5183,6 +2980,15 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "name" : "productRole",
+          "in" : "query",
+          "description" : "productRole",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "204" : {
@@ -5253,6 +3059,15 @@
           "in" : "query",
           "description" : "productId",
           "required" : true,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productRole",
+          "in" : "query",
+          "description" : "productRole",
+          "required" : false,
           "style" : "form",
           "schema" : {
             "type" : "string"
@@ -5331,6 +3146,15 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "name" : "productRole",
+          "in" : "query",
+          "description" : "productRole",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "204" : {
@@ -5375,52 +3199,6 @@
   },
   "components" : {
     "schemas" : {
-      "AdditionalInformations" : {
-        "title" : "AdditionalInformations",
-        "type" : "object",
-        "properties" : {
-          "agentOfPublicService" : {
-            "type" : "boolean",
-            "description" : "The institution is an agent of a public service",
-            "example" : false
-          },
-          "agentOfPublicServiceNote" : {
-            "type" : "string",
-            "description" : "agentOfPublicService Note"
-          },
-          "belongRegulatedMarket" : {
-            "type" : "boolean",
-            "description" : "The institution belongs to a regulated market",
-            "example" : false
-          },
-          "establishedByRegulatoryProvision" : {
-            "type" : "boolean",
-            "description" : "The institution is a company established by a regulatory provision",
-            "example" : false
-          },
-          "establishedByRegulatoryProvisionNote" : {
-            "type" : "string",
-            "description" : "establishedByRegulatoryProvision Note"
-          },
-          "ipa" : {
-            "type" : "boolean",
-            "description" : "The institution is registered on IPA",
-            "example" : false
-          },
-          "ipaCode" : {
-            "type" : "string",
-            "description" : "IPA code"
-          },
-          "otherNote" : {
-            "type" : "string",
-            "description" : "Other note"
-          },
-          "regulatedMarketNote" : {
-            "type" : "string",
-            "description" : "regulatedMarket Note"
-          }
-        }
-      },
       "Attribute" : {
         "title" : "Attribute",
         "type" : "object",
@@ -5652,26 +3430,73 @@
           }
         }
       },
-      "DpoData" : {
-        "title" : "DpoData",
-        "required" : [ "address", "email", "pec" ],
+      "DelegationWithInfo" : {
+        "title" : "DelegationWithInfo",
         "type" : "object",
         "properties" : {
-          "address" : {
-            "type" : "string",
-            "description" : "DPO's address"
+          "brokerId" : {
+            "type" : "string"
           },
-          "email" : {
-            "type" : "string",
-            "description" : "DPO's email",
-            "format" : "email",
-            "example" : "email@example.com"
+          "brokerName" : {
+            "type" : "string"
           },
-          "pec" : {
+          "brokerTaxCode" : {
+            "type" : "string"
+          },
+          "brokerType" : {
+            "type" : "string"
+          },
+          "createdAt" : {
             "type" : "string",
-            "description" : "DPO's PEC",
-            "format" : "email",
-            "example" : "email@example.com"
+            "format" : "date-time"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "institutionId" : {
+            "type" : "string"
+          },
+          "institutionName" : {
+            "type" : "string"
+          },
+          "institutionRootName" : {
+            "type" : "string"
+          },
+          "institutionType" : {
+            "type" : "string",
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+          },
+          "productId" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "taxCode" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "AOO", "PT", "UO" ]
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "DelegationWithPagination" : {
+        "title" : "DelegationWithPagination",
+        "type" : "object",
+        "properties" : {
+          "delegations" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/DelegationWithInfo"
+            }
+          },
+          "pageInfo" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
@@ -5861,74 +3686,6 @@
           }
         }
       },
-      "InstitutionInfo" : {
-        "title" : "InstitutionInfo",
-        "required" : [ "address", "fiscalCode", "institutionType", "mailAddress", "name", "vatNumber", "zipCode" ],
-        "type" : "object",
-        "properties" : {
-          "additionalInformations" : {
-            "description" : "Institution's additional informations",
-            "$ref" : "#/components/schemas/AdditionalInformations"
-          },
-          "address" : {
-            "type" : "string",
-            "description" : "Institution's physical address"
-          },
-          "city" : {
-            "type" : "string",
-            "description" : "Institution's city"
-          },
-          "country" : {
-            "type" : "string",
-            "description" : "Institution's country"
-          },
-          "county" : {
-            "type" : "string",
-            "description" : "Institution's county"
-          },
-          "dpoData" : {
-            "description" : "Data Protection Officer (DPO) specific data",
-            "$ref" : "#/components/schemas/DpoData"
-          },
-          "fiscalCode" : {
-            "type" : "string",
-            "description" : "Fiscal code corresponding to the institution"
-          },
-          "id" : {
-            "type" : "string",
-            "description" : "Institution's unique internal identifier"
-          },
-          "institutionType" : {
-            "type" : "string",
-            "description" : "Institution's type",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
-          },
-          "mailAddress" : {
-            "type" : "string",
-            "description" : "Institution's email address"
-          },
-          "name" : {
-            "type" : "string",
-            "description" : "Institution's name"
-          },
-          "pspData" : {
-            "description" : "Payment Service Provider (PSP) specific data",
-            "$ref" : "#/components/schemas/PspData"
-          },
-          "recipientCode" : {
-            "type" : "string",
-            "description" : "Billing recipient code"
-          },
-          "vatNumber" : {
-            "type" : "string",
-            "description" : "Institution's VAT number"
-          },
-          "zipCode" : {
-            "type" : "string",
-            "description" : "Institution's zipCode"
-          }
-        }
-      },
       "InstitutionResource" : {
         "title" : "InstitutionResource",
         "type" : "object",
@@ -6095,45 +3852,6 @@
           }
         }
       },
-      "InstitutionUserResource" : {
-        "title" : "InstitutionUserResource",
-        "type" : "object",
-        "properties" : {
-          "email" : {
-            "type" : "string",
-            "description" : "User's personal email"
-          },
-          "id" : {
-            "type" : "string",
-            "description" : "User's unique identifier",
-            "format" : "uuid"
-          },
-          "name" : {
-            "type" : "string",
-            "description" : "User's name"
-          },
-          "products" : {
-            "type" : "array",
-            "description" : "Authorized user products",
-            "items" : {
-              "$ref" : "#/components/schemas/ProductInfoResource"
-            }
-          },
-          "role" : {
-            "type" : "string",
-            "description" : "User's role",
-            "enum" : [ "ADMIN", "LIMITED" ]
-          },
-          "status" : {
-            "type" : "string",
-            "description" : "User's status"
-          },
-          "surname" : {
-            "type" : "string",
-            "description" : "User's surname"
-          }
-        }
-      },
       "InvalidParam" : {
         "title" : "InvalidParam",
         "required" : [ "name", "reason" ],
@@ -6193,34 +3911,25 @@
           }
         }
       },
-      "OnboardingRequestResource" : {
-        "title" : "OnboardingRequestResource",
-        "required" : [ "institutionInfo", "status" ],
+      "PageInfo" : {
+        "title" : "PageInfo",
         "type" : "object",
         "properties" : {
-          "admins" : {
-            "type" : "array",
-            "description" : "Administrators specific data",
-            "items" : {
-              "$ref" : "#/components/schemas/UserInfo"
-            }
+          "pageNo" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "institutionInfo" : {
-            "description" : "Institution specific data",
-            "$ref" : "#/components/schemas/InstitutionInfo"
+          "pageSize" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "manager" : {
-            "description" : "Manager specific data. It's required when institutionType is not PT",
-            "$ref" : "#/components/schemas/UserInfo"
+          "totalElements" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "productId" : {
-            "type" : "string",
-            "description" : "Product's identifier"
-          },
-          "status" : {
-            "type" : "string",
-            "description" : "Onboarding request's status",
-            "enum" : [ "ACTIVE", "DELETED", "PENDING", "REJECTED", "SUSPENDED", "TOBEVALIDATED" ]
+          "totalPages" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },
@@ -6255,19 +3964,6 @@
             "type" : "integer",
             "description" : "The number of total pages",
             "format" : "int32"
-          }
-        }
-      },
-      "PartyProduct" : {
-        "title" : "PartyProduct",
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "string"
-          },
-          "onBoardingStatus" : {
-            "type" : "string",
-            "enum" : [ "ACTIVE", "INACTIVE", "PENDING" ]
           }
         }
       },
@@ -6478,16 +4174,6 @@
         "title" : "ProductsResource",
         "type" : "object",
         "properties" : {
-          "activatedAt" : {
-            "type" : "string",
-            "description" : "Date the products was activated",
-            "format" : "date-time"
-          },
-          "authorized" : {
-            "type" : "boolean",
-            "description" : "flag indicating whether the logged user has the authorization to manage the product",
-            "example" : false
-          },
           "backOfficeEnvironmentConfigurations" : {
             "type" : "array",
             "description" : "Environment-specific configurations for back-office redirection with Token Exchange",
@@ -6532,11 +4218,6 @@
             "type" : "string",
             "description" : "Product logo's background color"
           },
-          "productOnBoardingStatus" : {
-            "type" : "string",
-            "description" : "Product's onBoarding status",
-            "enum" : [ "ACTIVE", "INACTIVE", "PENDING" ]
-          },
           "status" : {
             "type" : "string",
             "description" : "Product's status",
@@ -6553,38 +4234,6 @@
           "urlPublic" : {
             "type" : "string",
             "description" : "URL that redirects to the public information webpage of the product"
-          },
-          "userRole" : {
-            "type" : "string",
-            "description" : "Logged user's role"
-          }
-        }
-      },
-      "PspData" : {
-        "title" : "PspData",
-        "required" : [ "abiCode", "businessRegisterNumber", "legalRegisterName", "legalRegisterNumber", "vatNumberGroup" ],
-        "type" : "object",
-        "properties" : {
-          "abiCode" : {
-            "type" : "string",
-            "description" : "PSP's ABI code"
-          },
-          "businessRegisterNumber" : {
-            "type" : "string",
-            "description" : "PSP's Business Register number"
-          },
-          "legalRegisterName" : {
-            "type" : "string",
-            "description" : "PSP's legal register name"
-          },
-          "legalRegisterNumber" : {
-            "type" : "string",
-            "description" : "PSP's legal register number"
-          },
-          "vatNumberGroup" : {
-            "type" : "boolean",
-            "description" : "PSP's Vat Number group",
-            "example" : false
           }
         }
       },
@@ -6720,6 +4369,12 @@
         "title" : "SupportResponse",
         "type" : "object",
         "properties" : {
+          "actionUrl" : {
+            "type" : "string"
+          },
+          "jwt" : {
+            "type" : "string"
+          },
           "redirectUrl" : {
             "type" : "string"
           }
@@ -6780,31 +4435,6 @@
           "name" : {
             "type" : "string",
             "description" : "Users group's name"
-          }
-        }
-      },
-      "UserDto" : {
-        "title" : "UserDto",
-        "required" : [ "email", "fiscalCode", "name", "surname" ],
-        "type" : "object",
-        "properties" : {
-          "email" : {
-            "type" : "string",
-            "description" : "User's institutional email",
-            "format" : "email",
-            "example" : "email@example.com"
-          },
-          "fiscalCode" : {
-            "type" : "string",
-            "description" : "User's fiscal code"
-          },
-          "name" : {
-            "type" : "string",
-            "description" : "User's name"
-          },
-          "surname" : {
-            "type" : "string",
-            "description" : "User's surname"
           }
         }
       },
@@ -6939,34 +4569,6 @@
             "type" : "string",
             "description" : "User's unique identifier",
             "format" : "uuid"
-          }
-        }
-      },
-      "UserInfo" : {
-        "title" : "UserInfo",
-        "required" : [ "email", "fiscalCode", "id", "name", "surname" ],
-        "type" : "object",
-        "properties" : {
-          "email" : {
-            "type" : "string",
-            "description" : "User's institutional email"
-          },
-          "fiscalCode" : {
-            "type" : "string",
-            "description" : "User's fiscal code"
-          },
-          "id" : {
-            "type" : "string",
-            "description" : "User's unique identifier",
-            "format" : "uuid"
-          },
-          "name" : {
-            "type" : "string",
-            "description" : "User's name"
-          },
-          "surname" : {
-            "type" : "string",
-            "description" : "User's surname"
           }
         }
       },

--- a/openApi/generated-dashboard-pnpg/dashboard-pnpg-swagger20.json
+++ b/openApi/generated-dashboard-pnpg/dashboard-pnpg-swagger20.json
@@ -73,89 +73,6 @@
         "summary": "createDelegation"
       }
     },
-    "/v1/institutions": {
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "authenticated",
-            "required": false,
-            "type": "boolean"
-          },
-          {
-            "in": "query",
-            "name": "authorities[0].authority",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "credentials",
-            "required": false,
-            "type": "object"
-          },
-          {
-            "in": "query",
-            "name": "details",
-            "required": false,
-            "type": "object"
-          },
-          {
-            "in": "query",
-            "name": "principal",
-            "required": false,
-            "type": "object"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema":{"$ref":"#/definitions/InstitutionBaseResourceArray"}
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "institutions"
-        ],
-        "description": "Service to get all the institutions related to logged user",
-        "operationId": "getInstitutionsUsingGET",
-        "summary": "getInstitutions"
-      }
-    },
     "/v1/institutions/products": {
       "get": {
         "produces": [
@@ -474,6 +391,41 @@
             "name": "productId",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "Institution's name to search",
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Order to show response NONE, ASC, DESC",
+            "enum": [
+              "ASC",
+              "DESC",
+              "NONE"
+            ],
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "page",
+            "format": "int32",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "description": "size",
+            "format": "int32",
+            "in": "query",
+            "name": "size",
+            "required": false,
+            "type": "integer"
           }
         ],
         "responses": {
@@ -656,698 +608,6 @@
         "summary": "Retrieve institution's delegations"
       }
     },
-    "/v1/institutions/{institutionId}/products/{productId}/users": {
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "path",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Product's unique identifier",
-            "in": "path",
-            "name": "productId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "User's role",
-            "enum": [
-              "ADMIN",
-              "LIMITED"
-            ],
-            "in": "query",
-            "name": "role",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "description": "User's roles in product",
-            "in": "query",
-            "name": "productRoles",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema":{"$ref":"#/definitions/ProductUserResourceArray"}
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "institutions"
-        ],
-        "description": "Service to get all the users related to a specific pair of institution-product",
-        "operationId": "getInstitutionProductUsersUsingGET",
-        "summary": "getInstitutionProductUsers"
-      },
-      "post": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "path",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Product's unique identifier",
-            "in": "path",
-            "name": "productId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "schema": {
-              "$ref": "#/definitions/CreateUserDto"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created",
-            "schema": {
-              "$ref": "#/definitions/UserIdResource"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "institutions"
-        ],
-        "description": "Service to Create a user related to a specific pair of institution-product",
-        "operationId": "createInstitutionProductUserUsingPOST",
-        "summary": "createInstitutionProductUser"
-      }
-    },
-    "/v1/institutions/{institutionId}/products/{productId}/users/{userId}": {
-      "put": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "path",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Product's unique identifier",
-            "in": "path",
-            "name": "productId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "User's unique identifier",
-            "in": "path",
-            "name": "userId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "schema": {
-              "$ref": "#/definitions/UserProductRoles"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "institutions"
-        ],
-        "description": "Service to add a new role/product to a specific user",
-        "operationId": "addUserProductRolesUsingPUT",
-        "summary": "addUserProductRoles"
-      }
-    },
-    "/v1/institutions/{institutionId}/users": {
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "path",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Product's unique identifier",
-            "in": "query",
-            "name": "productId",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "description": "User's role",
-            "enum": [
-              "ADMIN",
-              "LIMITED"
-            ],
-            "in": "query",
-            "name": "role",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "description": "User's roles in product",
-            "in": "query",
-            "name": "productRoles",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema":{"$ref":"#/definitions/InstitutionUserResourceArray"}
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "institutions"
-        ],
-        "deprecated": true,
-        "description": "Service to get all the users related to a specific institution",
-        "operationId": "getInstitutionUsersUsingGET",
-        "summary": "getInstitutionUsers"
-      }
-    },
-    "/v1/institutions/{institutionId}/users/{userId}": {
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "path",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "User's unique identifier",
-            "in": "path",
-            "name": "userId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/InstitutionUserDetailsResource"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "institutions"
-        ],
-        "description": "Service to get the users with the given user id related to a specific institution",
-        "operationId": "getInstitutionUserUsingGET",
-        "summary": "getInstitutionUser"
-      }
-    },
-    "/v1/onboarding-requests/approve/{tokenId}": {
-      "post": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Onboarding request's unique identifier",
-            "format": "uuid",
-            "in": "path",
-            "name": "tokenId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "onboarding"
-        ],
-        "description": "Service to approve a specific onboarding request",
-        "operationId": "approveOnboardingRequestUsingPOST",
-        "summary": "approveOnboardingRequest"
-      }
-    },
-    "/v1/onboarding-requests/reject/{tokenId}": {
-      "delete": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Onboarding request's unique identifier",
-            "format": "uuid",
-            "in": "path",
-            "name": "tokenId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "onboarding"
-        ],
-        "description": "Service to reject a specific onboarding request",
-        "operationId": "rejectOnboardingRequestUsingDELETE",
-        "summary": "rejectOnboardingRequest"
-      }
-    },
-    "/v1/onboarding-requests/{tokenId}": {
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Onboarding request's unique identifier",
-            "format": "uuid",
-            "in": "path",
-            "name": "tokenId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/OnboardingRequestResource"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "onboarding"
-        ],
-        "description": "Service to retrieve a specific onboarding request",
-        "operationId": "retrieveOnboardingRequestUsingGET",
-        "summary": "retrieveOnboardingRequest"
-      }
-    },
-    "/v1/pnPGInstitutions/{institutionId}/products": {
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "path",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema":{"$ref":"#/definitions/PartyProductArray"}
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "pnPGInstitutions"
-        ],
-        "description": "Service to get all the products related to a specific institution",
-        "operationId": "getPnPGInstitutionProductsUsingGET",
-        "summary": "getPnPGInstitutionProducts"
-      }
-    },
-    "/v1/products/{productId}/back-office": {
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Product's unique identifier",
-            "in": "path",
-            "name": "productId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "query",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Back Office environment",
-            "in": "query",
-            "name": "environment",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/STRINGWrapper"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "products"
-        ],
-        "description": "Service to trigger token exchange and redirect to product's back office URL",
-        "operationId": "retrieveProductBackofficeUsingGET",
-        "summary": "retrieveProductBackoffice"
-      }
-    },
     "/v1/products/{productId}/brokers/{institutionType}": {
       "get": {
         "produces": [
@@ -1487,251 +747,7 @@
         "summary": "getProductRoles"
       }
     },
-    "/v1/relationships/{relationshipId}": {
-      "delete": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Unique relationship identifier between User and Product",
-            "in": "path",
-            "name": "relationshipId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "relationships"
-        ],
-        "description": "Delete the relationship",
-        "operationId": "deleteRelationshipByIdUsingDELETE",
-        "summary": "deleteRelationshipById"
-      }
-    },
-    "/v1/relationships/{relationshipId}/activate": {
-      "post": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Unique relationship identifier between User and Product",
-            "in": "path",
-            "name": "relationshipId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "relationships"
-        ],
-        "description": "Activate the relationship",
-        "operationId": "activateRelationshipUsingPOST",
-        "summary": "activateRelationship"
-      }
-    },
-    "/v1/relationships/{relationshipId}/suspend": {
-      "post": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Unique relationship identifier between User and Product",
-            "in": "path",
-            "name": "relationshipId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "relationships"
-        ],
-        "description": "Suspend the relationship",
-        "operationId": "suspendRelationshipUsingPOST",
-        "summary": "suspendRelationship"
-      }
-    },
     "/v1/support": {
-      "post": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "text/html",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "authenticated",
-            "required": false,
-            "type": "boolean"
-          },
-          {
-            "in": "query",
-            "name": "authorities[0].authority",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "in": "query",
-            "name": "credentials",
-            "required": false,
-            "type": "object"
-          },
-          {
-            "in": "query",
-            "name": "details",
-            "required": false,
-            "type": "object"
-          },
-          {
-            "in": "query",
-            "name": "principal",
-            "required": false,
-            "type": "object"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "schema": {
-              "$ref": "#/definitions/SupportRequestDto"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema":{"$ref":"#/definitions/STRINGWrapper"}
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "external-v2",
-          "support"
-        ],
-        "description": "Service to retrieve Support contact's form",
-        "operationId": "sendSupportRequestUsingPOST",
-        "summary": "sendSupportRequest"
-      }
-    },
-    "/v1/support/request": {
       "post": {
         "consumes": [
           "application/json"
@@ -1813,1056 +829,12 @@
           }
         ],
         "tags": [
+          "external-v2",
           "support"
         ],
-        "deprecated": true,
         "description": "Service to retrieve Support contact's form",
-        "operationId": "getSupportRedirectUrlUsingPOST",
-        "summary": "getSupportRedirectUrl"
-      }
-    },
-    "/v1/token/exchange": {
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "query",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Product's unique identifier",
-            "in": "query",
-            "name": "productId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Back Office environment",
-            "in": "query",
-            "name": "environment",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/IdentityTokenResource"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "token"
-        ],
-        "description": "Service create an 'Identity Token' based on a Self Care session token",
-        "operationId": "exchangeUsingGET",
-        "summary": "exchange"
-      }
-    },
-    "/v1/token/exchange/fatturazione": {
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "query",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Back Office environment",
-            "in": "query",
-            "name": "environment",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/STRINGWrapper"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "token"
-        ],
-        "description": "Service to create a 'Billing Token' based on a Self Care session token",
-        "operationId": "billingTokenUsingGET",
-        "summary": "billingToken"
-      }
-    },
-    "/v1/user-groups": {
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Users group's institutionId",
-            "in": "query",
-            "name": "institutionId",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "description": "The page number to access (0 indexed, defaults to 0)",
-            "format": "int32",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "type": "integer"
-          },
-          {
-            "description": "Number of records per page (defaults to 20, max 2000)",
-            "format": "int32",
-            "in": "query",
-            "name": "size",
-            "required": false,
-            "type": "integer"
-          },
-          {
-            "collectionFormat": "multi",
-            "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-            "in": "query",
-            "items": {
-              "type": "string"
-            },
-            "name": "sort",
-            "required": false,
-            "type": "array"
-          },
-          {
-            "description": "Users group's productId",
-            "in": "query",
-            "name": "productId",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "description": "User's unique identifier",
-            "format": "uuid",
-            "in": "query",
-            "name": "userId",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/PageOfUserGroupPlainResource"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user-groups"
-        ],
-        "description": "Service that allows to get a list of UserGroup entities",
-        "operationId": "getUserGroupsUsingGET",
-        "summary": "getUserGroups"
-      }
-    },
-    "/v1/user-groups/": {
-      "post": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "schema": {
-              "$ref": "#/definitions/CreateUserGroupDto"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created",
-            "schema": {
-              "$ref": "#/definitions/UserGroupIdResource"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "409": {
-            "description": "Conflict"
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user-groups"
-        ],
-        "description": "Service that allows the insert of a new occurrence for the UserGroup entity",
-        "operationId": "createUserGroupUsingPOST",
-        "summary": "createUserGroup"
-      }
-    },
-    "/v1/user-groups/{id}": {
-      "delete": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Users group's unique identifier",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user-groups"
-        ],
-        "description": "Service that allows the deletion of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId": "deleteUserGroupUsingDELETE",
-        "summary": "deleteUserGroup"
-      },
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Users group's unique identifier",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Users group's institutionId",
-            "in": "query",
-            "name": "institutionId",
-            "required": false,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/UserGroupResource"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user-groups"
-        ],
-        "description": "Service to get a specific UserGroup entity",
-        "operationId": "getUserGroupByIdUsingGET",
-        "summary": "getUserGroupById"
-      },
-      "put": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Users group's unique identifier",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "schema": {
-              "$ref": "#/definitions/UpdateUserGroupDto"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "409": {
-            "description": "Conflict"
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user-groups"
-        ],
-        "description": "Service that allows the modification of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId": "updateUserGroupUsingPUT",
-        "summary": "updateUserGroup"
-      }
-    },
-    "/v1/user-groups/{id}/activate": {
-      "post": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Users group's unique identifier",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user-groups"
-        ],
-        "description": "Service that allows the activation of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId": "activateUserGroupUsingPOST",
-        "summary": "activateUserGroup"
-      }
-    },
-    "/v1/user-groups/{id}/members/{userId}": {
-      "post": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Users group's unique identifier",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "User's unique identifier",
-            "format": "uuid",
-            "in": "path",
-            "name": "userId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user-groups"
-        ],
-        "description": "Service to add a member to a specific UserGroup entity",
-        "operationId": "addMemberToUserGroupUsingPOST",
-        "summary": "addMemberToUserGroup"
-      }
-    },
-    "/v1/user-groups/{id}/suspend": {
-      "post": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Users group's unique identifier",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user-groups"
-        ],
-        "description": "Service that allows the suspension of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId": "suspendUserGroupUsingPOST",
-        "summary": "suspendUserGroup"
-      }
-    },
-    "/v1/user-groups/{userGroupId}/members/{userId}": {
-      "delete": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Users group's unique identifier",
-            "in": "path",
-            "name": "userGroupId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "User's unique identifier",
-            "format": "uuid",
-            "in": "path",
-            "name": "userId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user-groups"
-        ],
-        "description": "Service to delete a member from a specific UserGroup entity",
-        "operationId": "deleteMemberFromUserGroupUsingDELETE",
-        "summary": "deleteMemberFromUserGroup"
-      }
-    },
-    "/v1/users": {
-      "post": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "query",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "schema": {
-              "$ref": "#/definitions/UserDto"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Created",
-            "schema": {
-              "$ref": "#/definitions/UserIdResource"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user"
-        ],
-        "description": "Save new user",
-        "operationId": "saveUserUsingPOST",
-        "summary": "saveUser"
-      }
-    },
-    "/v1/users/search": {
-      "post": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "query",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "schema": {
-              "$ref": "#/definitions/SearchUserDto"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/UserResource"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user"
-        ],
-        "description": "Retrieve the user for a given fiscal code",
-        "operationId": "searchUsingPOST",
-        "summary": "search"
-      }
-    },
-    "/v1/users/{id}": {
-      "delete": {
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "User's unique identifier",
-            "format": "uuid",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user"
-        ],
-        "description": "Delete user using internal id",
-        "operationId": "deleteUserByIdUsingDELETE",
-        "summary": "deleteUserById"
-      },
-      "get": {
-        "produces": [
-          "application/json",
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "User's unique identifier",
-            "format": "uuid",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "query",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/UserResource"
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user"
-        ],
-        "description": "Retrieve the user by internal id",
-        "operationId": "getUserByInternalIdUsingGET",
-        "summary": "getUserByInternalId"
-      },
-      "put": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/problem+json"
-        ],
-        "parameters": [
-          {
-            "description": "User's unique identifier",
-            "format": "uuid",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Institution's unique internal identifier",
-            "in": "query",
-            "name": "institutionId",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "schema": {
-              "$ref": "#/definitions/UpdateUserDto"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "Bad Request",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "schema": {
-              "$ref": "#/definitions/Problem"
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": [
-              "global"
-            ]
-          }
-        ],
-        "tags": [
-          "user"
-        ],
-        "description": "Update previously added user",
-        "operationId": "updateUserUsingPUT",
-        "summary": "updateUser"
+        "operationId": "sendSupportRequestUsingPOST",
+        "summary": "sendSupportRequest"
       }
     },
     "/v2/institutions": {
@@ -3008,6 +980,114 @@
         "description": "Service to get a specific institution related to logged user",
         "operationId": "v2GetInstitution",
         "summary": "Service to get a specific institution related to logged user"
+      }
+    },
+    "/v2/institutions/{institutionId}/institutions": {
+      "get": {
+        "produces": [
+          "application/json",
+          "application/problem+json"
+        ],
+        "parameters": [
+          {
+            "description": "Technical partner's identifier",
+            "in": "path",
+            "name": "institutionId",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Product's identifier",
+            "in": "query",
+            "name": "productId",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Institution's name to search",
+            "in": "query",
+            "name": "search",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Order to show response NONE, ASC, DESC",
+            "enum": [
+              "ASC",
+              "DESC",
+              "NONE"
+            ],
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "page",
+            "exclusiveMinimum": false,
+            "format": "int32",
+            "in": "query",
+            "minimum": 0,
+            "name": "page",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "description": "size",
+            "exclusiveMinimum": false,
+            "format": "int32",
+            "in": "query",
+            "minimum": 1,
+            "name": "size",
+            "required": false,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/DelegationWithPagination"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/Problem"
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "global"
+            ]
+          }
+        ],
+        "tags": [
+          "institutions"
+        ],
+        "description": "Retrieve list of delegation using to",
+        "operationId": "getDelegationsUsingToUsingGET_1",
+        "summary": "Retrieve list of delegation using to"
       }
     },
     "/v2/institutions/{institutionId}/products/{productId}/users": {
@@ -3511,7 +1591,7 @@
           "token"
         ],
         "description": "Service to create a 'Billing Token' based on a Self Care session token",
-        "operationId": "billingTokenUsingGET_1",
+        "operationId": "billingTokenUsingGET",
         "summary": "billingToken"
       }
     },
@@ -3615,7 +1695,7 @@
           "user-groups"
         ],
         "description": "Service that allows to get a list of UserGroup entities",
-        "operationId": "getUserGroupsUsingGET_1",
+        "operationId": "getUserGroupsUsingGET",
         "summary": "getUserGroups"
       }
     },
@@ -3677,7 +1757,7 @@
           "user-groups"
         ],
         "description": "Service that allows the insert of a new occurrence for the UserGroup entity",
-        "operationId": "createUserGroupUsingPOST_1",
+        "operationId": "createUserGroupUsingPOST",
         "summary": "createUserGroup"
       }
     },
@@ -3729,7 +1809,7 @@
           "user-groups"
         ],
         "description": "Service that allows the deletion of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId": "deleteUserGroupUsingDELETE_1",
+        "operationId": "deleteUserGroupUsingDELETE",
         "summary": "deleteUserGroup"
       },
       "get": {
@@ -3796,7 +1876,7 @@
           "user-groups"
         ],
         "description": "Service to get a specific UserGroup entity",
-        "operationId": "getUserGroupByIdUsingGET_1",
+        "operationId": "getUserGroupByIdUsingGET",
         "summary": "getUserGroupById"
       },
       "put": {
@@ -3859,7 +1939,7 @@
           "user-groups"
         ],
         "description": "Service that allows the modification of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId": "updateUserGroupUsingPUT_1",
+        "operationId": "updateUserGroupUsingPUT",
         "summary": "updateUserGroup"
       }
     },
@@ -3911,7 +1991,7 @@
           "user-groups"
         ],
         "description": "Service that allows the activation of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId": "activateUserGroupUsingPOST_1",
+        "operationId": "activateUserGroupUsingPOST",
         "summary": "activateUserGroup"
       }
     },
@@ -3971,7 +2051,7 @@
           "user-groups"
         ],
         "description": "Service to add a member to a specific UserGroup entity",
-        "operationId": "addMemberToUserGroupUsingPOST_1",
+        "operationId": "addMemberToUserGroupUsingPOST",
         "summary": "addMemberToUserGroup"
       }
     },
@@ -4023,7 +2103,7 @@
           "user-groups"
         ],
         "description": "Service that allows the suspension of a specific occurrence for the UserGroup entity by an Admin user",
-        "operationId": "suspendUserGroupUsingPOST_1",
+        "operationId": "suspendUserGroupUsingPOST",
         "summary": "suspendUserGroup"
       }
     },
@@ -4083,7 +2163,7 @@
           "user-groups"
         ],
         "description": "Service to delete a member from a specific UserGroup entity",
-        "operationId": "deleteMemberFromUserGroupUsingDELETE_1",
+        "operationId": "deleteMemberFromUserGroupUsingDELETE",
         "summary": "deleteMemberFromUserGroup"
       }
     },
@@ -4432,6 +2512,13 @@
             "name": "productId",
             "required": true,
             "type": "string"
+          },
+          {
+            "description": "productRole",
+            "in": "query",
+            "name": "productRole",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {
@@ -4497,6 +2584,13 @@
             "in": "query",
             "name": "productId",
             "required": true,
+            "type": "string"
+          },
+          {
+            "description": "productRole",
+            "in": "query",
+            "name": "productRole",
+            "required": false,
             "type": "string"
           }
         ],
@@ -4564,6 +2658,13 @@
             "name": "productId",
             "required": true,
             "type": "string"
+          },
+          {
+            "description": "productRole",
+            "in": "query",
+            "name": "productRole",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {
@@ -4605,53 +2706,7 @@
       }
     }
   },
-  "definitions" : {"ProductUserResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductUserResource"}},"InstitutionBaseResourceArray":{"type": "array", "items": {"$ref": "#/definitions/InstitutionBaseResource"}},"ProductRoleMappingsResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductRoleMappingsResource"}},"BrokerResourceArray":{"type": "array", "items": {"$ref": "#/definitions/BrokerResource"}},"PartyProductArray":{"type": "array", "items": {"$ref": "#/definitions/PartyProduct"}},"InstitutionUserResourceArray":{"type": "array", "items": {"$ref": "#/definitions/InstitutionUserResource"}},"ProductUserResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductUserResource"}},"DelegationResourceArray":{"type": "array", "items": {"$ref": "#/definitions/DelegationResource"}},"DelegationResourceArray":{"type": "array", "items": {"$ref": "#/definitions/DelegationResource"}},"GeographicTaxonomyResourceArray":{"type": "array", "items": {"$ref": "#/definitions/GeographicTaxonomyResource"}},"ProductsResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductsResource"}},"STRINGWrapper":{"type": "string"},"STRINGArray":{"type": "array", "items": {"type": "string"}},"InstitutionBaseResourceArray":{"type": "array", "items": {"$ref": "#/definitions/InstitutionBaseResource"}},
-    "AdditionalInformations": {
-      "properties": {
-        "agentOfPublicService": {
-          "description": "The institution is an agent of a public service",
-          "example": false,
-          "type": "boolean"
-        },
-        "agentOfPublicServiceNote": {
-          "description": "agentOfPublicService Note",
-          "type": "string"
-        },
-        "belongRegulatedMarket": {
-          "description": "The institution belongs to a regulated market",
-          "example": false,
-          "type": "boolean"
-        },
-        "establishedByRegulatoryProvision": {
-          "description": "The institution is a company established by a regulatory provision",
-          "example": false,
-          "type": "boolean"
-        },
-        "establishedByRegulatoryProvisionNote": {
-          "description": "establishedByRegulatoryProvision Note",
-          "type": "string"
-        },
-        "ipa": {
-          "description": "The institution is registered on IPA",
-          "example": false,
-          "type": "boolean"
-        },
-        "ipaCode": {
-          "description": "IPA code",
-          "type": "string"
-        },
-        "otherNote": {
-          "description": "Other note",
-          "type": "string"
-        },
-        "regulatedMarketNote": {
-          "description": "regulatedMarket Note",
-          "type": "string"
-        }
-      },
-      "title": "AdditionalInformations",
-      "type": "object"
-    },
+  "definitions" : {"ProductUserResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductUserResource"}},"InstitutionBaseResourceArray":{"type": "array", "items": {"$ref": "#/definitions/InstitutionBaseResource"}},"ProductRoleMappingsResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductRoleMappingsResource"}},"BrokerResourceArray":{"type": "array", "items": {"$ref": "#/definitions/BrokerResource"}},"DelegationResourceArray":{"type": "array", "items": {"$ref": "#/definitions/DelegationResource"}},"DelegationResourceArray":{"type": "array", "items": {"$ref": "#/definitions/DelegationResource"}},"GeographicTaxonomyResourceArray":{"type": "array", "items": {"$ref": "#/definitions/GeographicTaxonomyResource"}},"STRINGWrapper":{"type": "string"},"STRINGArray":{"type": "array", "items": {"type": "string"}},"ProductsResourceArray":{"type": "array", "items": {"$ref": "#/definitions/ProductsResource"}},
     "Attribute": {
       "properties": {
         "code": {
@@ -4907,31 +2962,89 @@
       "title": "DelegationResource",
       "type": "object"
     },
-    "DpoData": {
+    "DelegationWithInfo": {
       "properties": {
-        "address": {
-          "description": "DPO's address",
+        "brokerId": {
           "type": "string"
         },
-        "email": {
-          "description": "DPO's email",
-          "example": "email@example.com",
-          "format": "email",
+        "brokerName": {
           "type": "string"
         },
-        "pec": {
-          "description": "DPO's PEC",
-          "example": "email@example.com",
-          "format": "email",
+        "brokerTaxCode": {
+          "type": "string"
+        },
+        "brokerType": {
+          "type": "string"
+        },
+        "createdAt": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "institutionId": {
+          "type": "string"
+        },
+        "institutionName": {
+          "type": "string"
+        },
+        "institutionRootName": {
+          "type": "string"
+        },
+        "institutionType": {
+          "enum": [
+            "AS",
+            "CON",
+            "GSP",
+            "PA",
+            "PG",
+            "PSP",
+            "PT",
+            "REC",
+            "SA",
+            "SCP"
+          ],
+          "type": "string"
+        },
+        "productId": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "taxCode": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "AOO",
+            "PT",
+            "UO"
+          ],
+          "type": "string"
+        },
+        "updatedAt": {
+          "format": "date-time",
           "type": "string"
         }
       },
-      "required": [
-        "address",
-        "email",
-        "pec"
-      ],
-      "title": "DpoData",
+      "title": "DelegationWithInfo",
+      "type": "object"
+    },
+    "DelegationWithPagination": {
+      "properties": {
+        "delegations": {
+          "items": {
+            "$ref": "#/definitions/DelegationWithInfo"
+          },
+          "type": "array"
+        },
+        "pageInfo": {
+          "$ref": "#/definitions/PageInfo"
+        }
+      },
+      "title": "DelegationWithPagination",
       "type": "object"
     },
     "GeographicTaxonomy": {
@@ -5138,93 +3251,6 @@
       "title": "InstitutionBaseResource",
       "type": "object"
     },
-    "InstitutionInfo": {
-      "properties": {
-        "additionalInformations": {
-          "$ref": "#/definitions/AdditionalInformations",
-          "description": "Institution's additional informations"
-        },
-        "address": {
-          "description": "Institution's physical address",
-          "type": "string"
-        },
-        "city": {
-          "description": "Institution's city",
-          "type": "string"
-        },
-        "country": {
-          "description": "Institution's country",
-          "type": "string"
-        },
-        "county": {
-          "description": "Institution's county",
-          "type": "string"
-        },
-        "dpoData": {
-          "$ref": "#/definitions/DpoData",
-          "description": "Data Protection Officer (DPO) specific data"
-        },
-        "fiscalCode": {
-          "description": "Fiscal code corresponding to the institution",
-          "type": "string"
-        },
-        "id": {
-          "description": "Institution's unique internal identifier",
-          "type": "string"
-        },
-        "institutionType": {
-          "description": "Institution's type",
-          "enum": [
-            "AS",
-            "CON",
-            "GSP",
-            "PA",
-            "PG",
-            "PSP",
-            "PT",
-            "REC",
-            "SA",
-            "SCP"
-          ],
-          "type": "string"
-        },
-        "mailAddress": {
-          "description": "Institution's email address",
-          "type": "string"
-        },
-        "name": {
-          "description": "Institution's name",
-          "type": "string"
-        },
-        "pspData": {
-          "$ref": "#/definitions/PspData",
-          "description": "Payment Service Provider (PSP) specific data"
-        },
-        "recipientCode": {
-          "description": "Billing recipient code",
-          "type": "string"
-        },
-        "vatNumber": {
-          "description": "Institution's VAT number",
-          "type": "string"
-        },
-        "zipCode": {
-          "description": "Institution's zipCode",
-          "type": "string"
-        }
-      },
-      "required": [
-        "address",
-        "fiscalCode",
-        "institutionType",
-        "mailAddress",
-        "name",
-        "vatNumber",
-        "zipCode"
-      ],
-      "title": "InstitutionInfo",
-      "type": "object"
-    },
     "InstitutionResource": {
       "properties": {
         "address": {
@@ -5405,48 +3431,6 @@
       "title": "InstitutionUserDetailsResource",
       "type": "object"
     },
-    "InstitutionUserResource": {
-      "properties": {
-        "email": {
-          "description": "User's personal email",
-          "type": "string"
-        },
-        "id": {
-          "description": "User's unique identifier",
-          "format": "uuid",
-          "type": "string"
-        },
-        "name": {
-          "description": "User's name",
-          "type": "string"
-        },
-        "products": {
-          "description": "Authorized user products",
-          "items": {
-            "$ref": "#/definitions/ProductInfoResource"
-          },
-          "type": "array"
-        },
-        "role": {
-          "description": "User's role",
-          "enum": [
-            "ADMIN",
-            "LIMITED"
-          ],
-          "type": "string"
-        },
-        "status": {
-          "description": "User's status",
-          "type": "string"
-        },
-        "surname": {
-          "description": "User's surname",
-          "type": "string"
-        }
-      },
-      "title": "InstitutionUserResource",
-      "type": "object"
-    },
     "InvalidParam": {
       "properties": {
         "name": {
@@ -5523,45 +3507,26 @@
       "title": "OnboardedProductResource",
       "type": "object"
     },
-    "OnboardingRequestResource": {
+    "PageInfo": {
       "properties": {
-        "admins": {
-          "description": "Administrators specific data",
-          "items": {
-            "$ref": "#/definitions/UserInfo"
-          },
-          "type": "array"
+        "pageNo": {
+          "format": "int64",
+          "type": "integer"
         },
-        "institutionInfo": {
-          "$ref": "#/definitions/InstitutionInfo",
-          "description": "Institution specific data"
+        "pageSize": {
+          "format": "int64",
+          "type": "integer"
         },
-        "manager": {
-          "$ref": "#/definitions/UserInfo",
-          "description": "Manager specific data. It's required when institutionType is not PT"
+        "totalElements": {
+          "format": "int64",
+          "type": "integer"
         },
-        "productId": {
-          "description": "Product's identifier",
-          "type": "string"
-        },
-        "status": {
-          "description": "Onboarding request's status",
-          "enum": [
-            "ACTIVE",
-            "DELETED",
-            "PENDING",
-            "REJECTED",
-            "SUSPENDED",
-            "TOBEVALIDATED"
-          ],
-          "type": "string"
+        "totalPages": {
+          "format": "int64",
+          "type": "integer"
         }
       },
-      "required": [
-        "institutionInfo",
-        "status"
-      ],
-      "title": "OnboardingRequestResource",
+      "title": "PageInfo",
       "type": "object"
     },
     "PageOfUserGroupPlainResource": {
@@ -5602,23 +3567,6 @@
         "totalPages"
       ],
       "title": "PageOfUserGroupPlainResource",
-      "type": "object"
-    },
-    "PartyProduct": {
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "onBoardingStatus": {
-          "enum": [
-            "ACTIVE",
-            "INACTIVE",
-            "PENDING"
-          ],
-          "type": "string"
-        }
-      },
-      "title": "PartyProduct",
       "type": "object"
     },
     "PaymentServiceProvider": {
@@ -5843,16 +3791,6 @@
     },
     "ProductsResource": {
       "properties": {
-        "activatedAt": {
-          "description": "Date the products was activated",
-          "format": "date-time",
-          "type": "string"
-        },
-        "authorized": {
-          "description": "flag indicating whether the logged user has the authorization to manage the product",
-          "example": false,
-          "type": "boolean"
-        },
         "backOfficeEnvironmentConfigurations": {
           "description": "Environment-specific configurations for back-office redirection with Token Exchange",
           "items": {
@@ -5897,15 +3835,6 @@
           "description": "Product logo's background color",
           "type": "string"
         },
-        "productOnBoardingStatus": {
-          "description": "Product's onBoarding status",
-          "enum": [
-            "ACTIVE",
-            "INACTIVE",
-            "PENDING"
-          ],
-          "type": "string"
-        },
         "status": {
           "description": "Product's status",
           "enum": [
@@ -5927,47 +3856,9 @@
         "urlPublic": {
           "description": "URL that redirects to the public information webpage of the product",
           "type": "string"
-        },
-        "userRole": {
-          "description": "Logged user's role",
-          "type": "string"
         }
       },
       "title": "ProductsResource",
-      "type": "object"
-    },
-    "PspData": {
-      "properties": {
-        "abiCode": {
-          "description": "PSP's ABI code",
-          "type": "string"
-        },
-        "businessRegisterNumber": {
-          "description": "PSP's Business Register number",
-          "type": "string"
-        },
-        "legalRegisterName": {
-          "description": "PSP's legal register name",
-          "type": "string"
-        },
-        "legalRegisterNumber": {
-          "description": "PSP's legal register number",
-          "type": "string"
-        },
-        "vatNumberGroup": {
-          "description": "PSP's Vat Number group",
-          "example": false,
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "abiCode",
-        "businessRegisterNumber",
-        "legalRegisterName",
-        "legalRegisterNumber",
-        "vatNumberGroup"
-      ],
-      "title": "PspData",
       "type": "object"
     },
     "RootParentResponse": {
@@ -6113,6 +4004,12 @@
     },
     "SupportResponse": {
       "properties": {
+        "actionUrl": {
+          "type": "string"
+        },
+        "jwt": {
+          "type": "string"
+        },
         "redirectUrl": {
           "type": "string"
         }
@@ -6180,36 +4077,6 @@
         "name"
       ],
       "title": "UpdateUserGroupDto",
-      "type": "object"
-    },
-    "UserDto": {
-      "properties": {
-        "email": {
-          "description": "User's institutional email",
-          "example": "email@example.com",
-          "format": "email",
-          "type": "string"
-        },
-        "fiscalCode": {
-          "description": "User's fiscal code",
-          "type": "string"
-        },
-        "name": {
-          "description": "User's name",
-          "type": "string"
-        },
-        "surname": {
-          "description": "User's surname",
-          "type": "string"
-        }
-      },
-      "required": [
-        "email",
-        "fiscalCode",
-        "name",
-        "surname"
-      ],
-      "title": "UserDto",
       "type": "object"
     },
     "UserGroupIdResource": {
@@ -6354,40 +4221,6 @@
         }
       },
       "title": "UserIdResource",
-      "type": "object"
-    },
-    "UserInfo": {
-      "properties": {
-        "email": {
-          "description": "User's institutional email",
-          "type": "string"
-        },
-        "fiscalCode": {
-          "description": "User's fiscal code",
-          "type": "string"
-        },
-        "id": {
-          "description": "User's unique identifier",
-          "format": "uuid",
-          "type": "string"
-        },
-        "name": {
-          "description": "User's name",
-          "type": "string"
-        },
-        "surname": {
-          "description": "User's surname",
-          "type": "string"
-        }
-      },
-      "required": [
-        "email",
-        "fiscalCode",
-        "id",
-        "name",
-        "surname"
-      ],
-      "title": "UserInfo",
       "type": "object"
     },
     "UserProductRoles": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mui/x-data-grid": "^5.0.1",
     "@mui/x-data-grid-generator": "^5.0.1",
     "@pagopa/mui-italia": "^1.4.0",
-    "@pagopa/selfcare-common-frontend": "^1.34.16",
+    "@pagopa/selfcare-common-frontend": "^1.34.20",
     "@testing-library/react-hooks": "^8.0.1",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",

--- a/src/api/DashboardApi.ts
+++ b/src/api/DashboardApi.ts
@@ -41,21 +41,11 @@ const onRedirectToLogin = () =>
 
 export const DashboardApi = {
   getInstitutions: async (): Promise<Array<InstitutionBaseResource>> => {
-    const result = await apiClient.getInstitutionsUsingGET({});
-    return extractResponse(result, 200, onRedirectToLogin);
-  },
-
-  getInstitutionsV2: async (): Promise<Array<InstitutionBaseResource>> => {
     const result = await apiClient.v2RetrieveUserInstitutions({});
     return extractResponse(result, 200, onRedirectToLogin);
   },
 
   getInstitution: async (institutionId: string): Promise<InstitutionResource> => {
-    const result = await apiClient.getInstitutionUsingGET({ institutionId });
-    return extractResponse(result, 200, onRedirectToLogin);
-  },
-
-  getInstitutionV2: async (institutionId: string): Promise<InstitutionResource> => {
     const result = await apiClient.v2GetInstitution({ institutionId });
     return extractResponse(result, 200, onRedirectToLogin);
   },
@@ -88,19 +78,6 @@ export const DashboardApi = {
   },
 
   retrieveProductBackoffice: async (
-    productId: string,
-    institutionId: string,
-    environment?: string
-  ): Promise<string> => {
-    const result = await apiClient.retrieveProductBackofficeUsingGET({
-      productId,
-      institutionId,
-      environment,
-    });
-    return extractResponse(result, 200, onRedirectToLogin);
-  },
-
-  retrieveProductBackofficeV2: async (
     productId: string,
     institutionId: string,
     environment?: string

--- a/src/model/Product.tsx
+++ b/src/model/Product.tsx
@@ -36,7 +36,6 @@ export const productResource2Product = (resource: ProductsResource): Product => 
   id: resource.id ?? '',
   imageUrl: resource.imageUrl ?? '',
   logo: resource.logo ?? '',
-  activationDateTime: resource.activatedAt,
   status: resource.status ?? StatusEnum.INACTIVE,
   title: resource.title ?? '',
   urlBO: resource.urlBO ?? '',

--- a/src/model/__tests__/Product.test.ts
+++ b/src/model/__tests__/Product.test.ts
@@ -28,7 +28,6 @@ test('Test institutionInfo2Party', () => {
     title: 'SEND',
     description: 'Descrizione SEND',
     status: StatusEnum.ACTIVE,
-    activationDateTime: undefined,
     backOfficeEnvironmentConfigurations: undefined,
     urlBO: 'http://notifiche/bo?token=<IdentityToken>',
     urlPublic: 'http://notifiche/public',

--- a/src/services/partyService.ts
+++ b/src/services/partyService.ts
@@ -5,7 +5,6 @@ import {
   institutionResource2Party,
   Party,
 } from '../model/Party';
-import { ENV } from '../utils/env';
 import { mockedBaseInstitutions, mockedInstitutions } from './__mocks__/partyService';
 
 export const fetchParties = (): Promise<Array<BaseParty>> => {
@@ -13,11 +12,6 @@ export const fetchParties = (): Promise<Array<BaseParty>> => {
   if (process.env.REACT_APP_MOCK_API === 'true') {
     return new Promise((resolve) => resolve(mockedBaseInstitutions));
   } else {
-    if (ENV.USER.ENABLE_USER_V2) {
-      return DashboardApi.getInstitutionsV2().then((institutions) =>
-        institutions ? institutions.map(institutionBaseResource2BaseParty) : []
-      );
-    }
     return DashboardApi.getInstitutions().then((institutions) =>
       institutions ? institutions.map(institutionBaseResource2BaseParty) : []
     );
@@ -30,11 +24,6 @@ export const fetchPartyDetails = (partyId: string): Promise<Party | null> => {
     const selectedPartyDetail = mockedInstitutions?.find((p) => p.partyId === partyId) ?? null;
     return new Promise((resolve) => resolve(selectedPartyDetail));
   } else {
-    if (ENV.USER.ENABLE_USER_V2) {
-      return DashboardApi.getInstitutionV2(partyId).then((institutionResource) =>
-        institutionResource ? institutionResource2Party(institutionResource) : null
-      );
-    }
     return DashboardApi.getInstitution(partyId).then((institutionResource) =>
       institutionResource ? institutionResource2Party(institutionResource) : null
     );

--- a/src/services/tokenExchangeService.ts
+++ b/src/services/tokenExchangeService.ts
@@ -1,15 +1,9 @@
 import { DashboardApi } from '../api/DashboardApi';
 import { Party } from '../model/Party';
 import { Product } from '../model/Product';
-import { ENV } from '../utils/env';
 
 export const retrieveBackOfficeUrl = (
   selectedParty: Party,
   product: Product,
   environment?: string
-): Promise<string> => {
-  if (ENV.USER.ENABLE_USER_V2) {
-    return DashboardApi.retrieveProductBackofficeV2(product.id, selectedParty.partyId, environment);
-  }
-  return DashboardApi.retrieveProductBackoffice(product.id, selectedParty.partyId, environment);
-};
+): Promise<string> => DashboardApi.retrieveProductBackoffice(product.id, selectedParty.partyId, environment);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,7 +1916,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pagopa/mui-italia@^1.1.0", "@pagopa/mui-italia@^1.4.0":
+"@pagopa/mui-italia@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@pagopa/mui-italia/-/mui-italia-1.4.0.tgz#4e377db0a9e87bc12884ebb7bb17c0e57b0febe1"
   integrity sha512-8BmKRPKX0gxJpRl57/z2S/ZAosTazDp2BwjxbomCAcieiuF6f1o0Qj/ui2x2WHeGTmJzzWhucH+f0qAkPskxgQ==
@@ -1942,10 +1942,10 @@
     write-yaml-file "^4.1.3"
     yargs "^15.0.1"
 
-"@pagopa/selfcare-common-frontend@^1.34.16":
-  version "1.34.16"
-  resolved "https://registry.yarnpkg.com/@pagopa/selfcare-common-frontend/-/selfcare-common-frontend-1.34.16.tgz#2123a9df794c9fb6a179da668cf80d45a91fdd24"
-  integrity sha512-HRiGh3sF+ZRbM+St56j/YY/l5GDkwcrkwz3LZthbd0ey4+gx5l7iDvJekz2eTBB6qBR6bAaqC2JqfugW0UDaWQ==
+"@pagopa/selfcare-common-frontend@^1.34.20":
+  version "1.34.20"
+  resolved "https://registry.yarnpkg.com/@pagopa/selfcare-common-frontend/-/selfcare-common-frontend-1.34.20.tgz#a948d07cd041d8cfa0903c3f03b65ecc48b47104"
+  integrity sha512-kOjZgQk7QkgFJahz80yV5c0oCaas17SCy37eT9GtKn6hHlA6Iaud8SvRDyASD+1zdwkMiM0Q8WfcVB/Lu/mQ9A==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@emotion/styled" "^11.11.0"
@@ -1953,7 +1953,7 @@
     "@mui/lab" "^5.0.0-alpha.137"
     "@mui/material" "^5.14.1"
     "@mui/system" "^5.14.1"
-    "@pagopa/mui-italia" "^1.1.0"
+    "@pagopa/mui-italia" "^1.4.0"
     "@pagopa/ts-commons" "^10.2.1"
     "@reduxjs/toolkit" "^1.6.2"
     "@types/lodash" "^4.14.172"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
updated selfcare commons version
updated swagger to reomove v2
<!--- Describe your changes in detail -->

#### Motivation and Context
To read from url query params the lang
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested in local environment setting the language on the query parameter, the portal language changes and the correct language is selected in the switch on the footer
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.